### PR TITLE
fix: ensure locales folder included in package

### DIFF
--- a/packages/@interaxyz/mobile/package.json
+++ b/packages/@interaxyz/mobile/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "src",
+    "locales",
     "plugin/build",
     "app.plugin.js"
   ],

--- a/packages/@interaxyz/mobile/src/config.ts
+++ b/packages/@interaxyz/mobile/src/config.ts
@@ -9,6 +9,7 @@ import { LaunchArguments } from 'react-native-launch-arguments'
 import { HomeActionName } from 'src/home/types'
 import { ToggleableOnboardingFeatures } from 'src/onboarding/types'
 import { stringToBoolean } from 'src/utils/parsing'
+import * as secretsFile from '../secrets.json'
 import { ONE_HOUR_IN_MILLIS } from './utils/time'
 
 export interface ExpectedLaunchArgs {
@@ -17,12 +18,6 @@ export interface ExpectedLaunchArgs {
 }
 
 // extract secrets from secrets.json
-let secretsFile = {}
-try {
-  secretsFile = require('../secrets.json')
-} catch {
-  // TODO: remove secrets file and set secrets another way
-}
 const keyOrUndefined = (file: any, secretsKey: any, attribute: any) => {
   if (secretsKey in file) {
     if (attribute in file[secretsKey]) {

--- a/packages/@interaxyz/mobile/src/config.ts
+++ b/packages/@interaxyz/mobile/src/config.ts
@@ -5,7 +5,6 @@ import { SpendMerchant } from 'src/fiatExchanges/Spend'
 import { LoggerLevel } from 'src/utils/LoggerLevels'
 // eslint-disable-next-line import/no-relative-packages
 import { TORUS_SAPPHIRE_NETWORK } from '@toruslabs/constants'
-import { existsSync } from 'fs'
 import { LaunchArguments } from 'react-native-launch-arguments'
 import { HomeActionName } from 'src/home/types'
 import { ToggleableOnboardingFeatures } from 'src/onboarding/types'
@@ -18,7 +17,12 @@ export interface ExpectedLaunchArgs {
 }
 
 // extract secrets from secrets.json
-const secretsFile = existsSync('../secrets.json') ? require('../secrets.json') : {}
+let secretsFile = {}
+try {
+  secretsFile = require('../secrets.json')
+} catch {
+  // TODO: remove secrets file and set secrets another way
+}
 const keyOrUndefined = (file: any, secretsKey: any, attribute: any) => {
   if (secretsKey in file) {
     if (attribute in file[secretsKey]) {

--- a/packages/@interaxyz/mobile/src/config.ts
+++ b/packages/@interaxyz/mobile/src/config.ts
@@ -5,11 +5,11 @@ import { SpendMerchant } from 'src/fiatExchanges/Spend'
 import { LoggerLevel } from 'src/utils/LoggerLevels'
 // eslint-disable-next-line import/no-relative-packages
 import { TORUS_SAPPHIRE_NETWORK } from '@toruslabs/constants'
+import { existsSync } from 'fs'
 import { LaunchArguments } from 'react-native-launch-arguments'
 import { HomeActionName } from 'src/home/types'
 import { ToggleableOnboardingFeatures } from 'src/onboarding/types'
 import { stringToBoolean } from 'src/utils/parsing'
-import * as secretsFile from '../secrets.json'
 import { ONE_HOUR_IN_MILLIS } from './utils/time'
 
 export interface ExpectedLaunchArgs {
@@ -18,6 +18,7 @@ export interface ExpectedLaunchArgs {
 }
 
 // extract secrets from secrets.json
+const secretsFile = existsSync('../secrets.json') ? require('../secrets.json') : {}
 const keyOrUndefined = (file: any, secretsKey: any, attribute: any) => {
   if (secretsKey in file) {
     if (attribute in file[secretsKey]) {


### PR DESCRIPTION
### Description

Fixes some runtime error:
- `Unable to resolve "../../locales" from "node_modules/@interaxyz/mobile/src/i18n/index.ts"`

### Test plan

n/a

### Related issues

Related to RET-1289

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
