### PR TITLE
fix: make secrets.json optional

### DIFF
--- a/packages/@interaxyz/mobile/src/config.ts
+++ b/packages/@interaxyz/mobile/src/config.ts
@@ -9,7 +9,6 @@ import { LaunchArguments } from 'react-native-launch-arguments'
 import { HomeActionName } from 'src/home/types'
 import { ToggleableOnboardingFeatures } from 'src/onboarding/types'
 import { stringToBoolean } from 'src/utils/parsing'
-import * as secretsFile from '../secrets.json'
 import { ONE_HOUR_IN_MILLIS } from './utils/time'
 
 export interface ExpectedLaunchArgs {
@@ -18,6 +17,12 @@ export interface ExpectedLaunchArgs {
 }
 
 // extract secrets from secrets.json
+let secretsFile = {}
+try {
+  secretsFile = require('../secrets.json')
+} catch {
+  // TODO: remove the secrets file and inject secrets another way
+}
 const keyOrUndefined = (file: any, secretsKey: any, attribute: any) => {
   if (secretsKey in file) {
     if (attribute in file[secretsKey]) {


### PR DESCRIPTION
### Description

Solves the runtime error `Unable to resolve "../secrets.json" from "node_modules/@interaxyz/mobile/src/config.ts"`

### Test plan

n/a

### Related issues

- Related to RET-1289

### Backwards compatibility

<!-- Brief explanation of why these changes are/are not backwards compatible. -->

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
