### PR TITLE
fix: remove flipper from store setup

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -63,6 +63,8 @@ const config: KnipConfig = {
         '@types/jest',
         'husky',
         '@tsconfig/node-lts', // used in plugin/tsconfig.json
+        'react-native-flipper',
+        'redux-flipper',
       ],
       ignore: [
         'src/redux/reducersForSchemaGeneration.ts', // used for root state schema generation

--- a/packages/@interaxyz/mobile/src/redux/store.ts
+++ b/packages/@interaxyz/mobile/src/redux/store.ts
@@ -111,50 +111,6 @@ export const setupStore = (initialState?: ReducersRootState, config = persistCon
 
   const middlewares: Middleware[] = [sagaMiddleware, ...apiMiddlewares]
 
-  if (__DEV__ && !process.env.JEST_WORKER_ID) {
-    const createDebugger = require('redux-flipper').default
-    // Sending the whole state makes the redux debugger in flipper super slow!!
-    // I suspect it's the exchange rates causing this!
-    // For now exclude the `exchange`, `tokens`, & `priceHistory` reducers.
-    // They can be uncommented if needed for debugging.
-    middlewares.push(
-      createDebugger({
-        stateWhitelist: [
-          'app',
-          'dapps',
-          'i18n',
-          'networkInfo',
-          'alert',
-          'goldToken',
-          'stableToken',
-          'send',
-          'positions',
-          'points',
-          'home',
-          'transactions',
-          'web3',
-          'identity',
-          'account',
-          'invite',
-          'fees',
-          'recipients',
-          'localCurrency',
-          'imports',
-          'paymentRequest',
-          'fiatConnect',
-          'keylessBackup',
-          'nfts',
-          'swap',
-          'jumpstart',
-          'earn',
-          // 'exchange',
-          // 'tokens',
-          // 'priceHistory',
-        ],
-      })
-    )
-  }
-
   const persistedReducer = persistReducer(config, rootReducer)
 
   const createdStore = configureStore({


### PR DESCRIPTION
### Description

This change removes the need to include `react-native-flipper` and `redux-flipper` in end applications. Expo does not use flipper anyway.

### Test plan

n/a

### Related issues

- Related to RET-1289

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
