### PR TITLE
ci: allow dry-run in merge queue and address deprecation notice

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,13 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 jobs:
   publish:
     name: ${{ github.ref == 'refs/heads/main' && 'Publish' || 'Publish (dry-run)' }}
     # Only run if the test workflow succeeded or it's a PR (where we don't want to delay the dry run)
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'pull_request' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write # to be able to publish a GitHub release

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
       [
         "@semantic-release/github",
         {
-          "successComment": false,
+          "successCommentCondition": false,
           "releasedLabels": false
         }
       ]


### PR DESCRIPTION
### Description

I noticed the `Release dry-run` check didn't run in the merge queue, preventing the "required" statement from working.
i.e. it only ran during in the PR, but not while in the merge queue, causing the merge queue to reject the PR.

Also fixed this:

```
[9:36:17 PM] [@interaxyz/mobile] [@semantic-release/github] › ⚠  DEPRECATION: 'false' for 'successComment' is deprecated and will be removed in a future major version. Use 'successCommentCondition' instead.
```
