### PR TITLE
fix: remove secrets file require

### DIFF
--- a/packages/@interaxyz/mobile/src/analytics/AppAnalytics.test.ts
+++ b/packages/@interaxyz/mobile/src/analytics/AppAnalytics.test.ts
@@ -208,6 +208,7 @@ describe('AppAnalytics', () => {
 
     mockConfig.STATSIG_API_KEY = 'statsig-key'
     mockConfig.STATSIG_ENABLED = true
+    mockConfig.SEGMENT_API_KEY = 'segment-key'
     mockStore.getState.mockImplementation(() => state)
     jest.mocked(getFeatureGate).mockReturnValue(true)
     jest.mocked(getMultichainFeatures).mockReturnValue({

--- a/packages/@interaxyz/mobile/src/config.ts
+++ b/packages/@interaxyz/mobile/src/config.ts
@@ -16,13 +16,8 @@ export interface ExpectedLaunchArgs {
   onboardingOverrides?: string // same format as ONBOARDING_FEATURES_ENABLED env var
 }
 
-// extract secrets from secrets.json
-let secretsFile = {}
-try {
-  secretsFile = require('../secrets.json')
-} catch {
-  // TODO: remove the secrets file and inject secrets another way
-}
+// TODO: remove the secrets file and inject secrets another way
+const secretsFile = {}
 const keyOrUndefined = (file: any, secretsKey: any, attribute: any) => {
   if (secretsKey in file) {
     if (attribute in file[secretsKey]) {


### PR DESCRIPTION
### Description

The require was causing issues in the consumer apps, with the exception not being correctly caught. 

### Test plan

n/a

### Related issues

- Related to RET-1289

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
