### PR TITLE
fix: allow unsetting welcome background image

### DIFF
--- a/packages/@interaxyz/mobile/src/onboarding/welcome/Welcome.tsx
+++ b/packages/@interaxyz/mobile/src/onboarding/welcome/Welcome.tsx
@@ -65,7 +65,10 @@ export default function Welcome() {
   const assetsConfig = getAppConfig().themes?.default?.assets
 
   const Logo = assetsConfig?.welcomeLogo ?? WelcomeLogo
-  const backgroundImage = assetsConfig?.welcomeBackgroundImage ?? welcomeBackground
+  const backgroundImage =
+    assetsConfig && 'welcomeBackgroundImage' in assetsConfig
+      ? assetsConfig.welcomeBackgroundImage
+      : welcomeBackground
 
   return (
     <SafeAreaView style={styles.container}>


### PR DESCRIPTION
### Description

As the title - without this change, the flowers are displayed but for Beefy we should show no image.

### Test plan

n/a

### Related issues

- Related to RET-1289

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
