### PR TITLE
fix: unset android status bar background color

### DIFF
--- a/packages/@interaxyz/mobile/src/app/App.tsx
+++ b/packages/@interaxyz/mobile/src/app/App.tsx
@@ -85,6 +85,7 @@ export class App extends React.Component<Props> {
                 <StatusBar
                   backgroundColor="transparent"
                   barStyle={this.isDarkTheme ? 'light-content' : 'dark-content'}
+                  translucent
                 />
                 <ErrorBoundary>
                   <GestureHandlerRootView style={{ flex: 1 }}>


### PR DESCRIPTION
### Description

As the title - without this change, if the theme is dark mode, the content changes is correctly light colored but the background remains light :/ the translucent setting is only for Android.

### Test plan

n/a

### Related issues

- Related to RET-1289

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
