### PR TITLE
fix: ensure firebase functions are correctly gated

### DIFF
--- a/packages/@interaxyz/mobile/src/firebase/firebase.ts
+++ b/packages/@interaxyz/mobile/src/firebase/firebase.ts
@@ -369,6 +369,11 @@ export function simpleReadChannel(key: string) {
 }
 
 export async function readOnceFromFirebase(path: string) {
+  if (!FIREBASE_ENABLED) {
+    Logger.info(`${TAG}/readOnceFromFirebase`, 'Firebase disabled')
+    return
+  }
+
   const timeout = new Promise<void>((_, reject) =>
     setTimeout(
       () => reject(Error(`Reading from Firebase @ ${path} timed out.`)),

--- a/packages/@interaxyz/mobile/src/firebase/saga.ts
+++ b/packages/@interaxyz/mobile/src/firebase/saga.ts
@@ -33,8 +33,7 @@ export function* initializeFirebase() {
     return
   }
   if (!FIREBASE_ENABLED) {
-    Logger.info(TAG, 'Firebase disabled')
-    yield* put(showError(ErrorMessages.FIREBASE_DISABLED))
+    Logger.info(`${TAG}/initializeFirebase`, 'Firebase disabled')
     return
   }
 


### PR DESCRIPTION
### Description

As the title - without this change, there are errors printed in the logs and some error banners that are triggered if Firebase is not configured in apps

### Test plan

n/a

### Related issues

- Related to RET-1289

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
