### PR TITLE
fix: add cloud backup ids

### DIFF
--- a/packages/@interaxyz/mobile/src/config.ts
+++ b/packages/@interaxyz/mobile/src/config.ts
@@ -91,9 +91,10 @@ export const FIREBASE_ENABLED = stringToBoolean(Config.FIREBASE_ENABLED || 'true
 export const SHOW_TESTNET_BANNER = stringToBoolean(Config.SHOW_TESTNET_BANNER || 'false')
 export const SENTRY_ENABLED = stringToBoolean(Config.SENTRY_ENABLED || 'false')
 
-// SECRETS
-export const WEB3AUTH_CLIENT_ID = keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'WEB3AUTH_CLIENT_ID')
+export const WEB3AUTH_CLIENT_ID =
+  'BH-yuQkutyRCHMwcTQu_zSpkbG5fGeJEoc45DeoW4krzESwLD6qhQXRCuTSrFU_-qbvIvLcZhUJv9G5xmoFip8M'
 
+// SECRETS
 export const ALCHEMY_ETHEREUM_API_KEY = keyOrUndefined(
   secretsFile,
   DEFAULT_TESTNET,
@@ -130,10 +131,7 @@ export const WALLET_CONNECT_PROJECT_ID =
   keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'WALLET_CONNECT_PROJECT_ID') ??
   // valora-e2e-client project in the WC project dashboard
   '8f6f2517f4485c013849d38717ec90d1'
-export const AUTH0_CLIENT_ID =
-  keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'AUTH0_CLIENT_ID') ??
-  // dev app client id as fallback for e2e tests
-  'YgsHPq93Egfap5Wc4iEQlGyQMqjLeBf2'
+export const AUTH0_CLIENT_ID = 'FS2sPfMvDBKy0udOoCbc4ao8HakvAR6b'
 
 export const AUTH0_DOMAIN = configOrThrow('AUTH0_DOMAIN')
 


### PR DESCRIPTION
### Description

Add the needed web3auth and auth0 client identifiers so cloud backup can work.
These are the production identifiers.

Not allowing them to be changed for now, as we'd like cloud backup to work across Intera apps.
