### PR TITLE
feat(assets): make onboardingSuccessImage configurable

### DIFF
--- a/packages/@interaxyz/mobile/src/app/App.tsx
+++ b/packages/@interaxyz/mobile/src/app/App.tsx
@@ -85,6 +85,7 @@ export class App extends React.Component<Props> {
                 <StatusBar
                   backgroundColor="transparent"
                   barStyle={this.isDarkTheme ? 'light-content' : 'dark-content'}
+                  translucent
                 />
                 <ErrorBoundary>
                   <GestureHandlerRootView style={{ flex: 1 }}>

--- a/packages/@interaxyz/mobile/src/onboarding/success/OnboardingSuccessScreen.tsx
+++ b/packages/@interaxyz/mobile/src/onboarding/success/OnboardingSuccessScreen.tsx
@@ -22,10 +22,7 @@ function OnboardingSuccessScreen() {
 
   const assetsConfig = getAppConfig().themes?.default?.assets
 
-  const image =
-    assetsConfig && 'onboardingSuccessImage' in assetsConfig
-      ? assetsConfig.onboardingSuccessImage
-      : undefined
+  const image = assetsConfig?.onboardingSuccessImage
 
   return (
     <View style={styles.container}>

--- a/packages/@interaxyz/mobile/src/onboarding/success/OnboardingSuccessScreen.tsx
+++ b/packages/@interaxyz/mobile/src/onboarding/success/OnboardingSuccessScreen.tsx
@@ -1,29 +1,43 @@
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Image, StyleSheet, Text, View } from 'react-native'
+import { getAppConfig } from 'src/appConfig'
 import { background } from 'src/images/Images'
 import Logo from 'src/images/Logo'
 import { nuxNavigationOptionsNoBackButton } from 'src/navigator/Headers'
-import { navigate } from 'src/navigator/NavigationService'
-import { Screens } from 'src/navigator/Screens'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 
 function OnboardingSuccessScreen() {
   useEffect(() => {
-    const timeout = setTimeout(() => navigate(Screens.ChooseYourAdventure), 3000)
+    // const timeout = setTimeout(() => navigate(Screens.ChooseYourAdventure), 3000)
 
-    return () => clearTimeout(timeout)
+    // return () => clearTimeout(timeout)
   }, [])
 
   const { t } = useTranslation()
 
+  const assetsConfig = getAppConfig().themes?.default?.assets
+
+  const image =
+    assetsConfig && 'onboardingSuccessImage' in assetsConfig ?
+    assetsConfig.onboardingSuccessImage : undefined
+
   return (
     <View style={styles.container}>
-      <Image source={background} style={styles.backgroundImage} />
-      <Logo color={colors.contentOnboardingComplete} size={70} />
-      <Text style={styles.text}>{t('success.message')}</Text>
+      {
+        image ? <>
+          <Image source={image} />
+          <Text style={styles.textWithImage}>{t('success.message')}</Text>
+        </> : (
+          <>
+          <Image source={background} style={styles.backgroundImage} />
+          <Logo color={colors.contentOnboardingComplete} size={70} />
+          <Text style={styles.textWithBackground}>{t('success.message')}</Text>
+          </>
+        )
+      }
     </View>
   )
 }
@@ -35,6 +49,7 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+    backgroundColor: colors.backgroundPrimary,
   },
   backgroundImage: {
     ...StyleSheet.absoluteFillObject,
@@ -42,7 +57,14 @@ const styles = StyleSheet.create({
     width: undefined,
     height: undefined,
   },
-  text: {
+  textWithImage: {
+    ...typeScale.titleLarge,
+    color: colors.accent,
+    marginTop: Spacing.Regular16,
+    marginBottom: 30,
+    textAlign: 'center',
+  },
+  textWithBackground: {
     ...typeScale.titleSmall,
     fontSize: 30,
     lineHeight: 36,
@@ -53,7 +75,7 @@ const styles = StyleSheet.create({
     shadowRadius: 2,
     shadowOpacity: 1,
     shadowColor: colors.softShadow,
-  },
+  }
 })
 
 export default OnboardingSuccessScreen

--- a/packages/@interaxyz/mobile/src/onboarding/success/OnboardingSuccessScreen.tsx
+++ b/packages/@interaxyz/mobile/src/onboarding/success/OnboardingSuccessScreen.tsx
@@ -23,23 +23,24 @@ function OnboardingSuccessScreen() {
   const assetsConfig = getAppConfig().themes?.default?.assets
 
   const image =
-    assetsConfig && 'onboardingSuccessImage' in assetsConfig ?
-    assetsConfig.onboardingSuccessImage : undefined
+    assetsConfig && 'onboardingSuccessImage' in assetsConfig
+      ? assetsConfig.onboardingSuccessImage
+      : undefined
 
   return (
     <View style={styles.container}>
-      {
-        image ? <>
+      {image ? (
+        <>
           <Image source={image} />
           <Text style={styles.textWithImage}>{t('success.message')}</Text>
-        </> : (
-          <>
+        </>
+      ) : (
+        <>
           <Image source={background} style={styles.backgroundImage} />
           <Logo color={colors.contentOnboardingComplete} size={70} />
           <Text style={styles.textWithBackground}>{t('success.message')}</Text>
-          </>
-        )
-      }
+        </>
+      )}
     </View>
   )
 }
@@ -77,7 +78,7 @@ const styles = StyleSheet.create({
     shadowRadius: 2,
     shadowOpacity: 1,
     shadowColor: colors.softShadow,
-  }
+  },
 })
 
 export default OnboardingSuccessScreen

--- a/packages/@interaxyz/mobile/src/onboarding/success/OnboardingSuccessScreen.tsx
+++ b/packages/@interaxyz/mobile/src/onboarding/success/OnboardingSuccessScreen.tsx
@@ -5,15 +5,17 @@ import { getAppConfig } from 'src/appConfig'
 import { background } from 'src/images/Images'
 import Logo from 'src/images/Logo'
 import { nuxNavigationOptionsNoBackButton } from 'src/navigator/Headers'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 
 function OnboardingSuccessScreen() {
   useEffect(() => {
-    // const timeout = setTimeout(() => navigate(Screens.ChooseYourAdventure), 3000)
+    const timeout = setTimeout(() => navigate(Screens.ChooseYourAdventure), 3000)
 
-    // return () => clearTimeout(timeout)
+    return () => clearTimeout(timeout)
   }, [])
 
   const { t } = useTranslation()

--- a/packages/@interaxyz/mobile/src/public/types.tsx
+++ b/packages/@interaxyz/mobile/src/public/types.tsx
@@ -1,3 +1,5 @@
+import { ImageSourcePropType } from "react-native";
+
 // Type for tab configuration
 export interface TabScreenConfig {
   name: string // Just a unique identifier for the screen
@@ -100,6 +102,7 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
         // TODO: refine this as we add more assets (e.g. do we want to group by type? or screens? etc)
         welcomeLogo?: React.ComponentType<any>
         welcomeBackgroundImage?: typeof require
+        onboardingSuccessImage?: ImageSourcePropType
       }
     }
   }

--- a/packages/@interaxyz/mobile/src/public/types.tsx
+++ b/packages/@interaxyz/mobile/src/public/types.tsx
@@ -1,4 +1,4 @@
-import { ImageSourcePropType } from "react-native";
+import { ImageSourcePropType } from 'react-native'
 
 // Type for tab configuration
 export interface TabScreenConfig {

--- a/packages/@interaxyz/mobile/src/public/types.tsx
+++ b/packages/@interaxyz/mobile/src/public/types.tsx
@@ -1,4 +1,4 @@
-import type { ImageSourcePropType } from 'react-native';
+import type { ImageSourcePropType } from 'react-native'
 
 // Type for tab configuration
 export interface TabScreenConfig {

--- a/packages/@interaxyz/mobile/src/public/types.tsx
+++ b/packages/@interaxyz/mobile/src/public/types.tsx
@@ -1,4 +1,4 @@
-import { ImageSourcePropType } from 'react-native'
+import type { ImageSourcePropType } from 'react-native';
 
 // Type for tab configuration
 export interface TabScreenConfig {


### PR DESCRIPTION
### Description

Updated the Onboarding Success screen to make the image optional:

#### Default config (Valora)

<img src="https://github.com/user-attachments/assets/7e63c605-6704-4783-8d55-0efdb511db00" width="400">

#### Beefy config

```
themes: {
    default: {
      colors: {
        backgroundPrimary: '#242843',
        accent: '#4EB258',

      },
      assets: {
        onboardingSuccessImage: require('./assets/cow-spaceship.png'),
      }
    }
  }
```
<img src="https://github.com/user-attachments/assets/c15cc3ac-99a7-421f-9b90-ba43726316e4" width="400">

### Test plan

<!-- Demonstrate the change is solid, or why it doesn't need testing.
Example: add any manual testing steps or scenarios (if not obvious), screenshots / videos if the pull request changes the user interface.
-->

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

Ensured this will work for Valora and Beefy

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
