### PR TITLE
chore: Make statsig API key configurable

### DIFF
--- a/packages/@interaxyz/mobile/src/config.ts
+++ b/packages/@interaxyz/mobile/src/config.ts
@@ -6,6 +6,7 @@ import { LoggerLevel } from 'src/utils/LoggerLevels'
 // eslint-disable-next-line import/no-relative-packages
 import { TORUS_SAPPHIRE_NETWORK } from '@toruslabs/constants'
 import { LaunchArguments } from 'react-native-launch-arguments'
+import { getAppConfig } from 'src/appConfig'
 import { HomeActionName } from 'src/home/types'
 import { ToggleableOnboardingFeatures } from 'src/onboarding/types'
 import { stringToBoolean } from 'src/utils/parsing'
@@ -18,6 +19,7 @@ export interface ExpectedLaunchArgs {
 
 // TODO: remove the secrets file and inject secrets another way
 const secretsFile = {}
+const appConfig = getAppConfig()
 const keyOrUndefined = (file: any, secretsKey: any, attribute: any) => {
   if (secretsKey in file) {
     if (attribute in file[secretsKey]) {
@@ -121,7 +123,7 @@ export const ALCHEMY_BASE_API_KEY = keyOrUndefined(
 )
 
 export const ZENDESK_API_KEY = keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'ZENDESK_API_KEY')
-export const STATSIG_API_KEY = keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'STATSIG_API_KEY')
+export const STATSIG_API_KEY = appConfig.statsigApiKey ?? DEFAULT_TESTNET
 export const STATSIG_ENABLED = !isE2EEnv && !!STATSIG_API_KEY
 export const SEGMENT_API_KEY = keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'SEGMENT_API_KEY')
 export const SENTRY_CLIENT_URL = keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'SENTRY_CLIENT_URL')

--- a/packages/@interaxyz/mobile/src/public/types.tsx
+++ b/packages/@interaxyz/mobile/src/public/types.tsx
@@ -21,6 +21,7 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
   registryName: string
   displayName: string
   deepLinkUrlScheme: string
+  statsigApiKey?: string
 
   // Platform specific configuration
   ios?: {


### PR DESCRIPTION
### Description

Config:
```
{ ...
  statsigApiKey: 'dummy-statsig-api-key',
... }
```

### Test plan

CI

### Related issues

- N/A

### Backwards compatibility

- N/A

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- N/A
