### PR TITLE
fix: only apply detox plugin for the e2e test

### DIFF
--- a/apps/example/app.json
+++ b/apps/example/app.json
@@ -1,5 +1,7 @@
 {
   "expo": {
+    // Using app.json for clarity in this example app.
+    // For more complex conditional configs, consider using app.config.js/ts instead.
     "name": "Intera",
     "slug": "intera",
     // TODO: use an Intera scheme
@@ -69,7 +71,7 @@
         }
       ],
       "@interaxyz/mobile",
-      "@config-plugins/detox",
+      "./plugins/withConditionalDetox",
       [
         "./plugins/withCustomGradleProperties",
         {

--- a/apps/example/plugins/withConditionalDetox.js
+++ b/apps/example/plugins/withConditionalDetox.js
@@ -1,0 +1,17 @@
+const { withPlugins } = require('@expo/config-plugins')
+
+/**
+ * Use this plugin to conditionally apply Detox plugin
+ * @param {ExpoConfig} config
+ * @return {ExpoConfig}
+ */
+module.exports = (config, properties = {}) => {
+  // Check if E2E testing is enabled via env variable
+  if (process.env.EXPO_PUBLIC_MOBILE_STACK_E2E === 'true') {
+    // Only apply Detox plugin if E2E testing is enabled
+    return withPlugins(config, ['@config-plugins/detox'])
+  }
+
+  // Return unmodified config if E2E testing is disabled
+  return config
+}

--- a/apps/example/plugins/withConditionalDetox.js
+++ b/apps/example/plugins/withConditionalDetox.js
@@ -6,9 +6,8 @@ const { withPlugins } = require('@expo/config-plugins')
  * @return {ExpoConfig}
  */
 module.exports = (config, properties = {}) => {
-  // Check if E2E testing is enabled via env variable
+  // Only apply Detox plugin if E2E testing is enabled
   if (process.env.EXPO_PUBLIC_MOBILE_STACK_E2E === 'true') {
-    // Only apply Detox plugin if E2E testing is enabled
     return withPlugins(config, ['@config-plugins/detox'])
   }
 


### PR DESCRIPTION
### Description

When running `yarn android` in the example app, we'd see this error:

<img src="https://github.com/user-attachments/assets/832aa721-341c-43e5-9208-e521f75d5356" width="50%" /> 

Cause by detox config.

We could allow all subdomains, but it needs to be conditional, and we don't want builders to blindly copy an unsafe config.
See https://github.com/expo/config-plugins/tree/main/packages/detox#yarn-e2eandroid-failed

Here I'm using a config plugin applying the detox config plugin conditionally.
We could have switched to an `app.config.js/ts` but since it's an example app app, I think it's better to keep it simple with `app.json`.

