### PR TITLE
feat: make quick actions carousel configurable

### DIFF
--- a/packages/@interaxyz/mobile/src/home/TabHome.tsx
+++ b/packages/@interaxyz/mobile/src/home/TabHome.tsx
@@ -13,6 +13,7 @@ import {
   phoneNumberVerifiedSelector,
   showNotificationSpotlightSelector,
 } from 'src/app/selectors'
+import { getAppConfig } from 'src/appConfig'
 import { ALERT_BANNER_DURATION, DEFAULT_TESTNET, SHOW_TESTNET_BANNER } from 'src/config'
 import ActionsCarousel from 'src/home/ActionsCarousel'
 import NotificationBox from 'src/home/NotificationBox'
@@ -61,6 +62,7 @@ function TabHome(_props: Props) {
   const showNftReward = canShowNftReward && isFocused && !showNotificationSpotlight
 
   const showZerionTransactionFeed = getFeatureGate(StatsigFeatureGates.SHOW_ZERION_TRANSACTION_FEED)
+  const showActionsCarousel = getAppConfig().experimental?.showActionsCarousel
 
   useEffect(() => {
     dispatch(visitHome())
@@ -126,18 +128,12 @@ function TabHome(_props: Props) {
   ) as React.ReactElement<RefreshControlProps>
 
   const flatListSections = [
-    {
-      key: 'ActionsCarousel',
-      component: <ActionsCarousel />,
-    },
+    ...(showActionsCarousel ? [{ key: 'ActionsCarousel', component: <ActionsCarousel /> }] : []),
     {
       key: 'NotificationBox',
       component: <NotificationBox showOnlyHomeScreenNotifications={true} />,
     },
-    {
-      key: 'TransactionFeed',
-      component: <TransactionFeed />,
-    },
+    { key: 'TransactionFeed', component: <TransactionFeed /> },
   ]
 
   const renderItem = ({ item }: { item: any }) => item.component

--- a/packages/@interaxyz/mobile/src/public/types.tsx
+++ b/packages/@interaxyz/mobile/src/public/types.tsx
@@ -179,5 +179,6 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
       enableBiometry?: boolean
       protectWallet?: boolean
     }
+    showActionsCarousel?: boolean
   }
 }

--- a/packages/@interaxyz/mobile/src/transactions/feed/TransactionFeedV2.tsx
+++ b/packages/@interaxyz/mobile/src/transactions/feed/TransactionFeedV2.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-native'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { SwapEvents } from 'src/analytics/Events'
+import { getAppConfig } from 'src/appConfig'
 import { NotificationVariant } from 'src/components/InLineNotification'
 import SectionHead from 'src/components/SectionHead'
 import Toast from 'src/components/Toast'
@@ -308,6 +309,7 @@ export default function TransactionFeedV2() {
   const dispatch = useDispatch()
 
   const showUKCompliantVariant = getFeatureGate(StatsigFeatureGates.SHOW_UK_COMPLIANT_VARIANT)
+  const showActionsCarousel = getAppConfig().experimental?.showActionsCarousel
 
   const allowedNetworkForTransfers = useAllowedNetworksForTransfers()
   const address = useSelector(walletAddressSelector)
@@ -515,7 +517,7 @@ export default function TransactionFeedV2() {
         initialNumToRender={20}
         ListHeaderComponent={
           <>
-            <ActionsCarousel />
+            {showActionsCarousel && <ActionsCarousel />}
             <NotificationBox showOnlyHomeScreenNotifications={true} />
           </>
         }


### PR DESCRIPTION
### Description

Adds the `showActionsCarousel` to the experimental config.

### Test plan

- [x] Tested locally on iOS.


### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
